### PR TITLE
Dimitrie/dev/normalisation of abstracts

### DIFF
--- a/SpeckleGrasshopper/SpeckleGrasshopper.csproj.user
+++ b/SpeckleGrasshopper/SpeckleGrasshopper.csproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
+    <StartProgram>C:\Program Files\Rhinoceros 5 %2864-bit%29\System\Rhino.exe</StartProgram>
   </PropertyGroup>
 </Project>

--- a/SpeckleGrasshopper/TestComponents/SpeckleConverterDebug.cs
+++ b/SpeckleGrasshopper/TestComponents/SpeckleConverterDebug.cs
@@ -21,103 +21,107 @@ using SpeckleGrasshopper.Properties;
 namespace SpeckleGrasshopper
 {
 
-    public class EncodeToSpeckle : GH_Component
+  public class EncodeToSpeckle : GH_Component
+  {
+
+    Converter c = new SpeckleRhinoConverter.RhinoConverter();
+
+    public EncodeToSpeckle( )
+      : base( "Serialiser", "SRL",
+          "Serialises a Rhino object to a Speckle object.",
+          "Speckle", "Converters" )
     {
-
-        Converter c = new SpeckleRhinoConverter.RhinoConverter();
-
-        public EncodeToSpeckle()
-          : base("Serialiser", "SRL",
-              "Serialises a Rhino object to a Speckle object.",
-              "Speckle", "Converters")
-        {
-        }
-
-        public override Guid ComponentGuid
-        {
-            get { return new Guid("{c4442de1-c440-40ba-8da7-33c89eb1a529}"); }
-        }
-
-        protected override void RegisterInputParams(GH_InputParamManager pManager)
-        {
-            pManager.AddGenericParameter("Object", "O", "Objects to convert.", GH_ParamAccess.item);
-        }
-
-        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
-        {
-            pManager.AddGenericParameter("Conversion Result String", "S", "Conversion result string.", GH_ParamAccess.item);
-            pManager.AddGenericParameter("Conversion Result", "R", "Conversion result object.", GH_ParamAccess.item);
-        }
-
-        protected override void SolveInstance(IGH_DataAccess DA)
-        {
-            object myObj = new object();
-            DA.GetData(0, ref myObj);
-
-            var result = c.ToSpeckle(myObj);
-            DA.SetData(0, JsonConvert.SerializeObject(result, Formatting.Indented));
-            DA.SetData(1, result);
-        }
-
-        /// <summary>
-        /// Provides an Icon for the component.
-        /// </summary>
-        protected override System.Drawing.Bitmap Icon
-        {
-            get
-            {
-                return Resources.GenericIconXS;
-            }
-        }
     }
 
-    public class DecodeFromSpeckle : GH_Component
+    public override Guid ComponentGuid
     {
-
-        Converter c = new SpeckleRhinoConverter.RhinoConverter();
-
-        public DecodeFromSpeckle()
-          : base("Deserialiser", "DSR",
-              "Deserialises Speckle (geometry) objects to Rhino objects.",
-              "Speckle", "Converters")
-        {
-        }
-
-        protected override void RegisterInputParams(GH_InputParamManager pManager)
-        {
-            pManager.AddGenericParameter("Object", "O", "Objects to cast.", GH_ParamAccess.item);
-        }
-
-        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
-        {
-            pManager.AddGenericParameter("Conversion Result", "R", "Conversion result object.", GH_ParamAccess.item);
-        }
-
-        protected override void SolveInstance(IGH_DataAccess DA)
-        {
-            object myObj = new object();
-            DA.GetData(0, ref myObj);
-
-            var cast = myObj as Grasshopper.Kernel.Types.GH_ObjectWrapper;
-            var result = c.ToNative((SpeckleObject) cast.Value);
-            DA.SetData(0, new Grasshopper.Kernel.Types.GH_ObjectWrapper(result));
-        }
-
-        /// <summary>
-        /// Provides an Icon for the component.
-        /// </summary>
-        protected override System.Drawing.Bitmap Icon
-        {
-            get
-            {
-                return Resources.GenericIconXS;
-            }
-        }
-
-        public override Guid ComponentGuid
-        {
-            get { return new Guid("{43b4f541-d914-471e-9f37-72291db2f2d4}"); }
-        }
+      get { return new Guid( "{c4442de1-c440-40ba-8da7-33c89eb1a529}" ); }
     }
+
+    protected override void RegisterInputParams( GH_InputParamManager pManager )
+    {
+      pManager.AddGenericParameter( "Object", "O", "Objects to convert.", GH_ParamAccess.item );
+    }
+
+    protected override void RegisterOutputParams( GH_OutputParamManager pManager )
+    {
+      pManager.AddGenericParameter( "Conversion Result String", "S", "Conversion result string.", GH_ParamAccess.item );
+      pManager.AddGenericParameter( "Conversion Result", "R", "Conversion result object.", GH_ParamAccess.item );
+    }
+
+    protected override void SolveInstance( IGH_DataAccess DA )
+    {
+      object myObj = null;
+      DA.GetData( 0, ref myObj );
+
+      var result = SpeckleCore.Converter.ToAbstract( myObj.GetType().GetProperty( "Value" ) );
+      DA.SetData( 0, JsonConvert.SerializeObject( result, Formatting.Indented ) );
+      DA.SetData( 1, result );
+    }
+
+    /// <summary>
+    /// Provides an Icon for the component.
+    /// </summary>
+    protected override System.Drawing.Bitmap Icon
+    {
+      get
+      {
+        return Resources.GenericIconXS;
+      }
+    }
+  }
+
+  public class DecodeFromSpeckle : GH_Component
+  {
+
+    Converter c = new SpeckleRhinoConverter.RhinoConverter();
+
+    public DecodeFromSpeckle( )
+      : base( "Deserialiser", "DSR",
+          "Deserialises Speckle (geometry) objects to Rhino objects.",
+          "Speckle", "Converters" )
+    {
+    }
+
+    protected override void RegisterInputParams( GH_InputParamManager pManager )
+    {
+      pManager.AddGenericParameter( "Object", "O", "Objects to cast.", GH_ParamAccess.item );
+    }
+
+    protected override void RegisterOutputParams( GH_OutputParamManager pManager )
+    {
+      pManager.AddGenericParameter( "Conversion Result", "R", "Conversion result object.", GH_ParamAccess.item );
+    }
+
+    protected override void SolveInstance( IGH_DataAccess DA )
+    {
+      object myObj = null;
+      DA.GetData( 0, ref myObj );
+
+      if ( myObj == null )
+        return;
+
+      var cast = myObj as Grasshopper.Kernel.Types.GH_ObjectWrapper;
+      var result = c.ToNative( ( SpeckleObject ) cast.Value );
+      //var result = SpeckleCore.Converter.FromAbstract( (SpeckleAbstract) cast.Value );
+      DA.SetData( 0, new Grasshopper.Kernel.Types.GH_ObjectWrapper( result ) );
+    }
+
+    /// <summary>
+    /// Provides an Icon for the component.
+    /// </summary>
+    protected override System.Drawing.Bitmap Icon
+    {
+      get
+      {
+        return Resources.GenericIconXS;
+      }
+    }
+
+    public override Guid ComponentGuid
+    {
+      get { return new Guid( "{43b4f541-d914-471e-9f37-72291db2f2d4}" ); }
+    }
+  }
 
 }

--- a/SpeckleGrasshopper/TestComponents/SpeckleConverterDebug.cs
+++ b/SpeckleGrasshopper/TestComponents/SpeckleConverterDebug.cs
@@ -54,9 +54,16 @@ namespace SpeckleGrasshopper
       object myObj = null;
       DA.GetData( 0, ref myObj );
 
-      var result = SpeckleCore.Converter.ToAbstract( myObj.GetType().GetProperty( "Value" ) );
-      DA.SetData( 0, JsonConvert.SerializeObject( result, Formatting.Indented ) );
-      DA.SetData( 1, result );
+      //var result = myObj.GetType().GetProperty( "Value" );
+      object result = null;
+      object conv;
+      if ( result != null )
+        conv = SpeckleCore.Converter.Serialise( result );
+      else
+        conv = SpeckleCore.Converter.Serialise( myObj );
+
+      DA.SetData( 0, JsonConvert.SerializeObject( conv, Formatting.Indented ) );
+      DA.SetData( 1, conv );
     }
 
     /// <summary>

--- a/SpeckleRhinoConverter/SpeckleRhGhConverter.cs
+++ b/SpeckleRhinoConverter/SpeckleRhGhConverter.cs
@@ -608,7 +608,15 @@ namespace SpeckleRhinoConverter
       return new Polyline( poly.Value.ToPoints() ).ToNurbsCurve();
     }
 
-    // TODO: Polycurve
+    public static SpecklePolyline ToSpeckle( this PolylineCurve poly )
+    {
+      Polyline polyline;
+      if ( poly.TryGetPolyline( out polyline ) )
+      {
+        return new SpecklePolyline( polyline.ToFlatArray() );
+      }
+      return null;
+    }
 
     public static SpecklePolycurve ToSpeckle( this PolyCurve p )
     {


### PR DESCRIPTION
debounces object selection/deselection events by 200ms to avoid getting things overcrowded. (fixed #106 )