### PR TITLE
Fixes #197

### DIFF
--- a/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
+++ b/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
@@ -46,7 +46,7 @@ namespace SpeckleRhinoConverter
       foreach ( var key in dict.Keys )
       {
         var myObj = dict[ key ];
-        if ( traversed.ContainsKey( myObj.GetHashCode() ) )
+        if (!(myObj.IsPrimitive || myObj == typeof(Decimal) || myObj == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
         {
           myDictionary.Add( key, new SpeckleAbstract() { _type = "ref", _ref = traversed[ myObj.GetHashCode() ] } );
           continue;

--- a/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
+++ b/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
@@ -46,7 +46,8 @@ namespace SpeckleRhinoConverter
       foreach ( var key in dict.Keys )
       {
         var myObj = dict[ key ];
-        if (!(myObj.IsPrimitive || myObj == typeof(Decimal) || myObj == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
+        Type t = myObj.GetType();
+        if (!(t.IsPrimitive || t == typeof(Decimal) || t == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
         {
           myDictionary.Add( key, new SpeckleAbstract() { _type = "ref", _ref = traversed[ myObj.GetHashCode() ] } );
           continue;


### PR DESCRIPTION
This adds a simple check when converting ArchivableDictionary objects to prevent identical basic types (primitives, strings, etc.) from being changed into references.

The change happens at line 49 in SpeckleRhGhConverter.cs, as proposed in issue #197.

I think the rest of the red and green is line-endings being changed... 