### PR TITLE
Fix for #197 and new CreateLotsOfUserData component

### DIFF
--- a/SpeckleGrasshopper/SpeckleGrasshopper.csproj
+++ b/SpeckleGrasshopper/SpeckleGrasshopper.csproj
@@ -80,6 +80,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="UserDataUtils\CreateLotsOfUserData.cs" />
     <Compile Include="UserDataUtils\CreateUserData.cs" />
     <Compile Include="UserDataUtils\CsvUserData.cs" />
     <Compile Include="UserDataUtils\ExpandUserDataComponent.cs" />

--- a/SpeckleGrasshopper/UserDataUtils/CreateLotsOfUserData.cs
+++ b/SpeckleGrasshopper/UserDataUtils/CreateLotsOfUserData.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Grasshopper.Kernel;
+using Rhino.Geometry;
+using Grasshopper.Kernel.Types;
+using Grasshopper.Kernel.Parameters;
+using System.Diagnostics;
+using Rhino.Collections;
+
+namespace SpeckleGrasshopper
+{
+    public class CreateLotsOfUserData : GH_Component
+    {
+
+        public CreateLotsOfUserData()  
+          : base("Create Lots of Custom User Data", "CLUD",
+              "Creates a custom user dictionary using lists of keys and values.",
+              "Speckle", "User Data Utils")
+        {
+        }
+
+        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
+        {
+            pManager.AddTextParameter("Keys", "K", "Keys to place in dictionary.", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Values", "V", "Values to attach to keys.", GH_ParamAccess.list);
+        }
+
+        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
+        {
+            pManager.AddGenericParameter("User Data", "UD", "The user data as an Archivable Dictionary.", GH_ParamAccess.item);
+        }
+
+        protected override void SolveInstance(IGH_DataAccess DA)
+        {
+            var props = new ArchivableDictionary();
+
+            List<string> m_key_list = new List<string>();
+            List<object> m_value_list = new List<object>();
+
+            if (!DA.GetDataList("Keys", m_key_list))
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "No keys supplied.");
+                return;
+            }
+            if (!DA.GetDataList("Values", m_value_list))
+            {
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "No values supplied.");
+              return;
+            }
+
+            int N = Math.Min(m_key_list.Count, m_value_list.Count);
+
+            for (int i = 0; i < N; ++i)
+            {
+                var key = m_key_list[i];
+
+                object ghInputProperty = m_value_list[i];
+
+                if (ghInputProperty == null)
+                {
+                    props.Set(key, "undefined");
+                    continue;
+                }
+
+                object valueExtract = ghInputProperty.GetType().GetProperty("Value").GetValue(ghInputProperty, null);
+
+                Debug.WriteLine(key + ": " + valueExtract.GetType().ToString());
+
+                GeometryBase geometry = getGeometryBase(valueExtract);
+
+                if (geometry != null)
+                {
+                    props.Set(key, geometry);
+                    continue;
+                }
+
+                if (valueExtract is double)
+                    props.Set(key, (double)valueExtract);
+
+                if (valueExtract is Int32 || valueExtract is Int64 || valueExtract is Int16 || valueExtract is int)
+                    props.Set(key, (int)valueExtract);
+
+                if (valueExtract is string)
+                    props.Set(key, (string)valueExtract);
+
+                if (valueExtract is bool)
+                    props.Set(key, (bool)valueExtract);
+
+                if (valueExtract is Vector3d)
+                    props.Set(key, (Vector3d)valueExtract);
+
+                if (valueExtract is Point3d)
+                    props.Set(key, (Point3d)valueExtract);
+
+                if (valueExtract is Line)
+                    props.Set(key, (Line)valueExtract);
+
+                if ((valueExtract is Circle))
+                    props.Set(key, new ArcCurve((Circle)valueExtract));
+
+                if (valueExtract is Interval)
+                    props.Set(key, (Interval)valueExtract);
+
+                if (valueExtract is UVInterval)
+                    props.Set(key, "UV Interval not supported.");
+
+                if (valueExtract is Plane)
+                    props.Set(key, (Plane)valueExtract);
+
+                if (valueExtract is ArchivableDictionary)
+                    props.Set(key, (ArchivableDictionary)valueExtract);
+            }
+
+            DA.SetData(0, props);
+        }
+
+        public GeometryBase getGeometryBase(object myObject)
+        { 
+            if (myObject is Rectangle3d) return ((Rectangle3d)myObject).ToNurbsCurve();
+            if (myObject is Polyline) return ((Polyline)myObject).ToNurbsCurve();
+            if (myObject is Box) return ((Box)myObject).ToBrep();
+
+            return myObject as GeometryBase;
+        }
+
+
+        protected override System.Drawing.Bitmap Icon
+        {
+            get
+            {
+                return Properties.Resources.CreateUserData;
+            }
+        }
+
+        public override Guid ComponentGuid
+        {
+            get { return new Guid("{d15e0aaa-65be-4882-92a0-021405e32f7b}"); }
+        }
+    }
+
+
+}

--- a/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
+++ b/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
@@ -46,7 +46,7 @@ namespace SpeckleRhinoConverter
       foreach ( var key in dict.Keys )
       {
         var myObj = dict[ key ];
-        if ( traversed.ContainsKey( myObj.GetHashCode() ) )
+        if (!(myObj.IsPrimitive || myObj == typeof(Decimal) || myObj == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
         {
           myDictionary.Add( key, new SpeckleAbstract() { _type = "ref", _ref = traversed[ myObj.GetHashCode() ] } );
           continue;

--- a/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
+++ b/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
@@ -47,13 +47,14 @@ namespace SpeckleRhinoConverter
       {
         var myObj = dict[ key ];
         Type t = myObj.GetType();
-        if (!(t.IsPrimitive || t == typeof(Decimal) || t == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
+        if (!(t.IsPrimitive || t == typeof(decimal) || t == typeof(string)) && traversed.ContainsKey( myObj.GetHashCode() ) )
         {
           myDictionary.Add( key, new SpeckleAbstract() { _type = "ref", _ref = traversed[ myObj.GetHashCode() ] } );
           continue;
         }
 
-        traversed.Add( myObj.GetHashCode(), path + "/" + key );
+        if (!(t.IsPrimitive || t == typeof(decimal) || t == typeof(string)))
+          traversed.Add( myObj.GetHashCode(), path + "/" + key );
 
         if ( dict[ key ] is ArchivableDictionary )
           myDictionary.Add( key, ( ( ArchivableDictionary ) dict[ key ] ).ToSpeckle( traversed, path + "/" + key, root ) );

--- a/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
+++ b/SpeckleRhinoConverter/src/SpeckleRhGhConverter.cs
@@ -46,7 +46,8 @@ namespace SpeckleRhinoConverter
       foreach ( var key in dict.Keys )
       {
         var myObj = dict[ key ];
-        if (!(myObj.IsPrimitive || myObj == typeof(Decimal) || myObj == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
+        Type t = myObj.GetType();
+        if (!(t.IsPrimitive || t == typeof(Decimal) || t == typeof(String)) && traversed.ContainsKey( myObj.GetHashCode() ) )
         {
           myDictionary.Add( key, new SpeckleAbstract() { _type = "ref", _ref = traversed[ myObj.GetHashCode() ] } );
           continue;


### PR DESCRIPTION
- Fix for #197 excludes primitives and strings from reference check.
- CreateLotsOfUserData component takes a list of keys and values and makes a dictionary out of them, using CreateUserData as a template.