### PR TITLE
Adds Manual Mode for Senders

### DIFF
--- a/SpeckleGrasshopper/SpeckleGrasshopper.csproj
+++ b/SpeckleGrasshopper/SpeckleGrasshopper.csproj
@@ -56,6 +56,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />


### PR DESCRIPTION
Via the context menu, you can select "Manual Mode". This means that all updates are deferred until the user presses the "play button", which will:
- create a stream clone and push add it to the stream's children
- force a new update to go through
