### PR TITLE
Stam/dev/gh add data speckle objects

### DIFF
--- a/SpeckleGrasshopper/GH_SpeckleObject.cs
+++ b/SpeckleGrasshopper/GH_SpeckleObject.cs
@@ -72,7 +72,7 @@ namespace SpeckleGrasshopper
       }
       try
       {
-        Value = Converter.Serialise( source ) as SpeckleObject;
+        Value = Converter.Serialise( source.GetType().GetProperty("Value").GetValue(source) ) as SpeckleObject;
         return true;
       }
       catch { return false; }
@@ -146,7 +146,7 @@ namespace SpeckleGrasshopper
 
   public class SpeckleObjectParameter : GH_PersistentParam<GH_SpeckleObject>
   {
-    public SpeckleObjectParameter() : this("SpeckleObject", "SpeckleObject", "This is a SpeckleObject.", "Speckle", "Parameters") { }
+    public SpeckleObjectParameter() : this("SpeckleObject", "SpeckleObject", "This is a SpeckleObject.", "Params", "Primitive") { }
     public SpeckleObjectParameter(string name, string nickname, string description, string category, string subcategory)
         : base(name, nickname, description, category, subcategory) { }
     public SpeckleObjectParameter(GH_InstanceDescription tag) : base(tag) { }

--- a/SpeckleGrasshopper/ObjectCreation/CreateSpeckleObject.cs
+++ b/SpeckleGrasshopper/ObjectCreation/CreateSpeckleObject.cs
@@ -5,7 +5,9 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Timers;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Parameters;
+using Grasshopper.Kernel.Types;
 using SpeckleCore;
 
 namespace SpeckleGrasshopper
@@ -16,35 +18,35 @@ namespace SpeckleGrasshopper
   {
     private Timer Debouncer;
 
-    public CreateSpeckleObject( )
-      : base( "Create a Custom Speckle Object", "CSO",
+    public CreateSpeckleObject()
+      : base("Create a Custom Speckle Object", "CSO",
           "Creates a custom speckle object with whatever propeties you want. You can set them at your ease.",
-          "Speckle", "Special" )
+          "Speckle", "Special")
     {
       this.Params.ParameterNickNameChanged += Params_ParameterNickNameChanged;
     }
 
-    public override void AddedToDocument( GH_Document document )
+    public override void AddedToDocument(GH_Document document)
     {
-      base.AddedToDocument( document );
-      Debouncer = new Timer( 2000 ); Debouncer.AutoReset = false;
-      Debouncer.Elapsed += ( sender, e ) =>
+      base.AddedToDocument(document);
+      Debouncer = new Timer(2000); Debouncer.AutoReset = false;
+      Debouncer.Elapsed += (sender, e) =>
       {
-        Rhino.RhinoApp.MainApplicationWindow.Invoke( ( Action ) delegate { this.ExpireSolution( true ); } );
+        Rhino.RhinoApp.MainApplicationWindow.Invoke((Action)delegate { this.ExpireSolution(true); });
       };
 
-      foreach ( var param in Params.Input )
+      foreach (var param in Params.Input)
       {
-        param.ObjectChanged += ( sender, e ) =>
+        param.ObjectChanged += (sender, e) =>
         {
           Debouncer.Start();
         };
       }
     }
 
-    private void Params_ParameterNickNameChanged( object sender, GH_ParamServerEventArgs e )
+    private void Params_ParameterNickNameChanged(object sender, GH_ParamServerEventArgs e)
     {
-      ExpireSolution( true );
+      ExpireSolution(true);
     }
 
     /// <summary>
@@ -52,7 +54,7 @@ namespace SpeckleGrasshopper
     /// </summary>
     public override Guid ComponentGuid
     {
-      get { return new Guid( "{7b758641-d781-4e15-bfd8-b6c723c9dd28}" ); }
+      get { return new Guid("{7b758641-d781-4e15-bfd8-b6c723c9dd28}"); }
     }
 
     /// <summary>
@@ -66,9 +68,9 @@ namespace SpeckleGrasshopper
       }
     }
 
-    public bool CanInsertParameter( GH_ParameterSide side, int index )
+    public bool CanInsertParameter(GH_ParameterSide side, int index)
     {
-      if ( side == GH_ParameterSide.Input )
+      if (side == GH_ParameterSide.Input)
       {
         return true;
       }
@@ -78,9 +80,9 @@ namespace SpeckleGrasshopper
       }
     }
 
-    public bool CanRemoveParameter( GH_ParameterSide side, int index )
+    public bool CanRemoveParameter(GH_ParameterSide side, int index)
     {
-      if ( side == GH_ParameterSide.Input && Params.Input.Count > 1 )
+      if (side == GH_ParameterSide.Input && Params.Input.Count > 1)
       {
         return true;
       }
@@ -90,92 +92,140 @@ namespace SpeckleGrasshopper
       }
     }
 
-    public IGH_Param CreateParameter( GH_ParameterSide side, int index )
+    public IGH_Param CreateParameter(GH_ParameterSide side, int index)
     {
-      Grasshopper.Kernel.Parameters.Param_GenericObject param = new Param_GenericObject();
+      var param = new Param_GenericAccess();
 
-      param.Name = GH_ComponentParamServer.InventUniqueNickname( "ABCDEFGHIJKLMNOPQRSTUVWXYZ", Params.Input );
+      param.Name = GH_ComponentParamServer.InventUniqueNickname("ABCDEFGHIJKLMNOPQRSTUVWXYZ", Params.Input);
       param.NickName = param.Name;
       param.Description = "Property Name";
       param.Optional = true;
       param.Access = GH_ParamAccess.item;
 
-      param.ObjectChanged += ( sender, e ) => Debouncer.Start();
+      param.ObjectChanged += (sender, e) => Debouncer.Start();
 
       return param;
     }
 
-    public bool DestroyParameter( GH_ParameterSide side, int index )
+    public bool DestroyParameter(GH_ParameterSide side, int index)
     {
       return true;
     }
 
-    public void VariableParameterMaintenance( )
+    public void VariableParameterMaintenance()
     {
       //ExpireSolution( true );
     }
 
-    protected override void RegisterInputParams( GH_InputParamManager pManager )
+    protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
-      pManager.AddGenericParameter( "A", "A", "Data.", GH_ParamAccess.item );
+      pManager.AddParameter(new Param_GenericAccess(), "A", "A", "Data.", GH_ParamAccess.item);
     }
 
-    protected override void RegisterOutputParams( GH_OutputParamManager pManager )
+    protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      pManager.AddGenericParameter( "Speckle Object", "SO", "The newly created speckle object.", GH_ParamAccess.item );
-      pManager.AddGenericParameter( "Dictionary", "D", "Just the dictionary.", GH_ParamAccess.item );
+      pManager.AddGenericParameter("Speckle Object", "SO", "The newly created speckle object.", GH_ParamAccess.item);
+      pManager.AddGenericParameter("Dictionary", "D", "Just the dictionary.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance( IGH_DataAccess DA )
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
 
       var check = ValidateKeys();
-      if ( check.Item1 )
+      if (check.Item1)
       {
-        AddRuntimeMessage( GH_RuntimeMessageLevel.Error, check.Item2 );
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, check.Item2);
         return;
       }
 
       var myDictionary = new Dictionary<string, object>();
 
-      for ( int i = 0; i < Params.Input.Count; i++ )
+      for (int i = 0; i < Params.Input.Count; i++)
       {
-        var key = Params.Input[ i ].NickName;
+        var key = Params.Input[i].NickName;
 
-        object ghInputProperty = null;
-        DA.GetData( i, ref ghInputProperty );
+        dynamic ghInputProperty = null;
+        object valueExtract = null;
+        switch (Params.Input[i].Access)
+        {
+          case GH_ParamAccess.item:
+            DA.GetData(i, ref ghInputProperty);
+            valueExtract = ghInputProperty?.Value;
+            break;
+          case GH_ParamAccess.list:
+            var dataValues = new List<dynamic>();
+            DA.GetDataList(i, dataValues);
+            valueExtract = dataValues.Select(x => x.Value).ToList();
+            break;
+          case GH_ParamAccess.tree:
+            var tree = new GH_Structure<IGH_Goo>();
+            DA.GetDataTree(i, out tree);
+            var dict = new Dictionary<string, IEnumerable<object>>();
 
-        if ( ghInputProperty == null ) continue;
+            for (int j = 0; j < tree.PathCount; j++)
+            {
+              var branch = tree.Branches[j];
+              var list = new List<object>();
+              for (int k = 0; k < branch.Count; k++)
+              {
+                list.Add(branch[k].GetType().GetProperty("Value").GetValue(branch[k], null));
+              }
+              //var value = branch.Select(x => x.GetType().GetProperty("Value").GetValue(x, null));
+              dict.Add(j.ToString(), list);
+            }
 
-        var valueExtract = ghInputProperty.GetType().GetProperty( "Value" ).GetValue( ghInputProperty, null );
+            myDictionary.Add(key, dict);
+            continue;
+          default:
+            continue;
+        }
+
+
+        //if (ghInputProperty == null) continue;
+
+        //var valueExtract = ghInputProperty?.Value;//.GetType().GetProperty( "Value" ).GetValue( ghInputProperty, null );
 
         try
         {
           var tests = valueExtract is IEnumerable<object>;
-
-          if ( valueExtract is IEnumerable<int> || valueExtract is IEnumerable<double> || valueExtract is IEnumerable<string> || valueExtract is IEnumerable<bool> )
+          if (valueExtract is IEnumerable<object>)
           {
-            myDictionary.Add( key, valueExtract );
+            var val = valueExtract as List<object>;
+            //Is this important? It replaced IEnumerable<int> 
+            if(val.Count > 0 && val[0] is int || val[0] is double || val[0] is string || val[1] is bool)
+            {
+              myDictionary.Add(key, val);
+            }
+            else
+            {
+              myDictionary.Add(key, Converter.Serialise(val));
+            }
           }
-          else if ( valueExtract is IEnumerable<object> )
-          {
-            //valueExtract = ( ( IEnumerable<object> ) valueExtract ).Select( o => o.GetType().GetProperty( "Value" ).GetValue( o, null ) );
-            myDictionary.Add( key, Converter.Serialise( valueExtract as IEnumerable<object> ) );
-          }
 
-          else if ( valueExtract is System.Collections.IDictionary )
+
+          //if (valueExtract is IEnumerable<int> || valueExtract is IEnumerable<double> || valueExtract is IEnumerable<string> || valueExtract is IEnumerable<bool>)
+          //{
+          //  //myDictionary.Add(key, valueExtract);
+          //}
+          //else if (valueExtract is IEnumerable<object>)
+          //{
+          //  //valueExtract = ( ( IEnumerable<object> ) valueExtract ).Select( o => o.GetType().GetProperty( "Value" ).GetValue( o, null ) );
+          //  //myDictionary.Add(key, Converter.Serialise(valueExtract as IEnumerable<object>));
+          //}
+
+          else if (valueExtract is System.Collections.IDictionary)
           {
-            myDictionary.Add( key, valueExtract );
+            myDictionary.Add(key, valueExtract);
           }
           else
           {
-            if ( valueExtract is bool || valueExtract is string || valueExtract is double || valueExtract is int )
-              myDictionary.Add( key, valueExtract );
+            if (valueExtract is bool || valueExtract is string || valueExtract is double || valueExtract is int)
+              myDictionary.Add(key, valueExtract);
             else
-              myDictionary.Add( key, Converter.Serialise( valueExtract ) );
+              myDictionary.Add(key, Converter.Serialise(valueExtract));
           }
         }
-        catch ( Exception e )
+        catch (Exception)
         {
           continue;
         }
@@ -184,48 +234,48 @@ namespace SpeckleGrasshopper
       var myObject = new SpeckleObject() { Properties = myDictionary };
       myObject.GenerateHash();
 
-      DA.SetData( 0, myObject );
-      DA.SetData( 1, myDictionary );
+      DA.SetData(0, myObject);
+      DA.SetData(1, myDictionary);
       //new GH_SpeckleObject()
     }
 
-    public Tuple<bool, string> ValidateKeys( )
+    public Tuple<bool, string> ValidateKeys()
     {
       List<string> keyNames = new List<string>();
       bool hasErrors = false;
       string validationErrors = "";
-      for ( int i = 0; i < Params.Input.Count; i++ )
+      for (int i = 0; i < Params.Input.Count; i++)
       {
-        var param = Params.Input[ i ];
-        if ( keyNames.Contains( param.NickName ) )
+        var param = Params.Input[i];
+        if (keyNames.Contains(param.NickName))
         {
-          this.AddRuntimeMessage( GH_RuntimeMessageLevel.Error, "Duplicate  key names found (" + param.NickName + "). Please use different values." );
+          this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Duplicate  key names found (" + param.NickName + "). Please use different values.");
 
           validationErrors += "Duplicate  key names found (" + param.NickName + "). Please use different values.\n";
 
           hasErrors = true;
         }
 
-        if ( param.NickName == "type" || param.NickName == "Type" )
+        if (param.NickName == "type" || param.NickName == "Type")
         {
-          this.AddRuntimeMessage( GH_RuntimeMessageLevel.Error, "Using 'Type' or 'type' as a key name is not possible. Please use different name, for example 'familiyType'. Thanks!" );
+          this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Using 'Type' or 'type' as a key name is not possible. Please use different name, for example 'familiyType'. Thanks!");
 
           validationErrors += "Using 'Type' or 'type' as a key name is not possible. Please use different name, for example 'familiyType'. Thanks!";
 
           hasErrors = true;
         }
 
-        if ( param.NickName.Contains( "." ) )
+        if (param.NickName.Contains("."))
         {
-          this.AddRuntimeMessage( GH_RuntimeMessageLevel.Error, "Dots in key names are not supported. Sorry!" );
+          this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Dots in key names are not supported. Sorry!");
 
           validationErrors += "Dots in key names are not supported. Sorry!";
         }
 
-        keyNames.Add( param.NickName );
+        keyNames.Add(param.NickName);
       }
 
-      return new Tuple<bool, string>( hasErrors, validationErrors );
+      return new Tuple<bool, string>(hasErrors, validationErrors);
     }
   }
 }

--- a/SpeckleGrasshopper/ObjectCreation/CreateSpeckleObject.cs
+++ b/SpeckleGrasshopper/ObjectCreation/CreateSpeckleObject.cs
@@ -170,7 +170,6 @@ namespace SpeckleGrasshopper
               {
                 list.Add(branch[k].GetType().GetProperty("Value").GetValue(branch[k], null));
               }
-              //var value = branch.Select(x => x.GetType().GetProperty("Value").GetValue(x, null));
               dict.Add(j.ToString(), list);
             }
 
@@ -179,11 +178,6 @@ namespace SpeckleGrasshopper
           default:
             continue;
         }
-
-
-        //if (ghInputProperty == null) continue;
-
-        //var valueExtract = ghInputProperty?.Value;//.GetType().GetProperty( "Value" ).GetValue( ghInputProperty, null );
 
         try
         {
@@ -201,18 +195,6 @@ namespace SpeckleGrasshopper
               myDictionary.Add(key, Converter.Serialise(val));
             }
           }
-
-
-          //if (valueExtract is IEnumerable<int> || valueExtract is IEnumerable<double> || valueExtract is IEnumerable<string> || valueExtract is IEnumerable<bool>)
-          //{
-          //  //myDictionary.Add(key, valueExtract);
-          //}
-          //else if (valueExtract is IEnumerable<object>)
-          //{
-          //  //valueExtract = ( ( IEnumerable<object> ) valueExtract ).Select( o => o.GetType().GetProperty( "Value" ).GetValue( o, null ) );
-          //  //myDictionary.Add(key, Converter.Serialise(valueExtract as IEnumerable<object>));
-          //}
-
           else if (valueExtract is System.Collections.IDictionary)
           {
             myDictionary.Add(key, valueExtract);

--- a/SpeckleGrasshopper/ObjectCreation/EncapsulateList.cs
+++ b/SpeckleGrasshopper/ObjectCreation/EncapsulateList.cs
@@ -11,6 +11,7 @@ namespace SpeckleGrasshopper
 {
   public class EncapsulateList : GH_Component
   {
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
 
     public EncapsulateList( )
       : base( "Encapsulate a List", "EL",

--- a/SpeckleGrasshopper/ObjectCreation/ExpandSpeckleObject.cs
+++ b/SpeckleGrasshopper/ObjectCreation/ExpandSpeckleObject.cs
@@ -23,62 +23,62 @@ namespace SpeckleGrasshopper
     /// <summary>
     /// Initializes a new instance of the MyComponent1 class.
     /// </summary>
-    public ExpandSpeckleObject( )
-      : base( "Expand Dictionary or SpeckleObject", "EUD",
+    public ExpandSpeckleObject()
+      : base("Expand Dictionary or SpeckleObject", "EUD",
           "Expands a SpeckleObject's properties or a dictionary into its component key value pairs.",
-          "Speckle", "Special" )
+          "Speckle", "Special")
     {
-      expireComponent = ( ) =>
+      expireComponent = () =>
       {
-        this.ExpireSolution( true );
+        this.ExpireSolution(true);
       };
 
-      setInputsAndExpireComponent = ( ) =>
+      setInputsAndExpireComponent = () =>
       {
-        for ( int i = Params.Output.Count - 1; i >= 0; i-- )
+        for (int i = Params.Output.Count - 1; i >= 0; i--)
         {
-          var myParam = Params.Output[ i ];
-          if ( ( !global.Keys.Contains( myParam.Name ) ) || ( !global.Keys.Contains( myParam.NickName ) ) )
+          var myParam = Params.Output[i];
+          if ((!global.Keys.Contains(myParam.Name)) || (!global.Keys.Contains(myParam.NickName)))
           {
-            Params.UnregisterOutputParameter( myParam, true );
+            Params.UnregisterOutputParameter(myParam, true);
           }
         }
 
         //Params.OnParametersChanged();
-        foreach ( var key in global.Keys )
+        foreach (var key in global.Keys)
         {
-          var myparam = Params.Output.FirstOrDefault( q => q.Name == key );
-          if ( myparam == null )
+          var myparam = Params.Output.FirstOrDefault(q => q.Name == key);
+          if (myparam == null)
           {
-            Param_GenericObject newParam = getGhParameter( key );
-            Params.RegisterOutputParam( newParam );
+            Param_GenericObject newParam = getGhParameter(key);
+            Params.RegisterOutputParam(newParam);
           }
         }
 
         Params.OnParametersChanged();
         //end
-        this.ExpireSolution( true );
+        this.ExpireSolution(true);
       };
     }
 
-    public override void AddedToDocument( GH_Document document )
+    public override void AddedToDocument(GH_Document document)
     {
-      base.AddedToDocument( document );
-      Debug.WriteLine( this.Params.Output.Count );
+      base.AddedToDocument(document);
+      Debug.WriteLine(this.Params.Output.Count);
     }
 
     /// <summary>
     /// Registers all the input parameters for this component.
     /// </summary>
-    protected override void RegisterInputParams( GH_Component.GH_InputParamManager pManager )
+    protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
     {
-      pManager.AddGenericParameter( "Dictionaries", "D", "Dictionaries or Speckle Objects to expand.", GH_ParamAccess.list );
+      pManager.AddGenericParameter("Dictionaries", "D", "Dictionaries or Speckle Objects to expand.", GH_ParamAccess.list);
     }
 
     /// <summary>
     /// Registers all the output parameters for this component.
     /// </summary>
-    protected override void RegisterOutputParams( GH_Component.GH_OutputParamManager pManager )
+    protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
     {
     }
 
@@ -86,144 +86,161 @@ namespace SpeckleGrasshopper
     /// This is the method that actually does the work.
     /// </summary>
     /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
-    protected override void SolveInstance( IGH_DataAccess DA )
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       List<object> objs = new List<object>();
-      objs = Params.Input[ 0 ].VolatileData.AllData( true ).ToList<object>();
+      objs = Params.Input[0].VolatileData.AllData(true).ToList<object>();
 
-      if ( objs.Count == 0 )
+      if (objs.Count == 0)
       {
-        this.AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, "No dictionaries found." );
+        this.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "No dictionaries found.");
         return;
       }
 
       global = new Dictionary<string, List<object>>();
       var first = true;
 
-      foreach ( var obj in objs )
+      foreach (var obj in objs)
       {
         var goo = obj as GH_ObjectWrapper;
-        if ( goo == null )
+        if (goo == null)
         {
-          this.AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, "We don't like nulls." );
+          this.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "We don't like nulls.");
           return;
         }
-        //ArchivableDictionary dict = goo.Value as ArchivableDictionary;
 
-        var dict = new Dictionary<string, object>();
-        if ( goo.Value is SpeckleObject )
-          dict = ( ( SpeckleObject ) goo.Value ).Properties;
-        else if ( goo.Value is Dictionary<string, object> )
+        Dictionary<string, object> dict = null;
+
+        if (goo.Value is SpeckleObject)
+          dict = ((SpeckleObject)goo.Value).Properties;
+        else if (goo.Value is Dictionary<string, object>)
           dict = goo.Value as Dictionary<string, object>;
-
-        if ( dict != null )
+        else if (goo.Value is Dictionary<string, IEnumerable<object>>)
         {
-          foreach ( var key in dict.Keys )
+          //Handle this Case right away
+          //For inputs that came from a DataTree
+          dict = goo.Value as Dictionary<string, object>;
+          var dict2 = goo.Value as Dictionary<string, IEnumerable<object>>;
+
+          foreach (var item in dict2)
           {
-            if ( ( first ) )
+            global.Add(item.Key, item.Value.ToList());
+          }
+
+          continue;
+        }
+        else
+          dict = new Dictionary<string, object>();
+
+
+        if (dict != null)
+        {
+          foreach (var key in dict.Keys)
+          {
+            if ((first))
             {
-              global.Add( key, new List<object>() );
-              global[ key ].Add( dict[ key ] );
+              global.Add(key, new List<object>());
+              global[key].Add(dict[key]);
             }
 
-            else if ( !global.Keys.Contains( key ) )
+            else if (!global.Keys.Contains(key))
             {
-              this.AddRuntimeMessage( GH_RuntimeMessageLevel.Error, "Object dictionaries do not match." );
+              this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Object dictionaries do not match.");
               return;
             }
             else
             {
-              global[ key ].Add( dict[ key ] );
+              global[key].Add(dict[key]);
             }
           }
         }
         first = false;
       }
 
-      if ( global.Keys.Count == 0 )
+      if (global.Keys.Count == 0)
       {
-        this.AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, "Empty dictionary." );
+        this.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Empty dictionary.");
         return;
       }
 
       var changed = false;
 
-      if ( Params.Output.Count != global.Keys.Count )
+      if (Params.Output.Count != global.Keys.Count)
       {
         changed = true;
       }
 
-      Debug.WriteLine( "changed:" + changed );
+      Debug.WriteLine("changed:" + changed);
 
-      if ( changed )
+      if (changed)
       {
-        Rhino.RhinoApp.MainApplicationWindow.Invoke( setInputsAndExpireComponent );
+        Rhino.RhinoApp.MainApplicationWindow.Invoke(setInputsAndExpireComponent);
       }
       else
       {
         int k = 0;
-        foreach ( var key in global.Keys )
+        foreach (var key in global.Keys)
         {
-          Params.Output[ k ].Name = Params.Output[ k ].NickName = key;
+          Params.Output[k].Name = Params.Output[k].NickName = key;
           var results = new List<object>();
           var isNestedList = false;
-          foreach ( var x in global[ key ] )
+          foreach (var x in global[key])
           {
             var t = x.GetType();
-            if ( x is IEnumerable<SpeckleObject> )
+            if (x is IEnumerable<SpeckleObject>)
             {
-              results.Add( Converter.Deserialise( x as IEnumerable<SpeckleObject> ) );
+              results.Add(Converter.Deserialise(x as IEnumerable<SpeckleObject>));
               isNestedList = true;
               continue;
             }
-            else if ( x is IEnumerable<int> || x is IEnumerable<double> || x is IEnumerable<string> || x is IEnumerable<bool> )
+            else if (x is IEnumerable<int> || x is IEnumerable<double> || x is IEnumerable<string> || x is IEnumerable<bool>)
             {
-              switch ( x )
+              switch (x)
               {
                 case IEnumerable<int> l:
-                  results.Add( l );
+                  results.Add(l);
                   break;
                 case IEnumerable<double> l:
-                  results.Add( l );
+                  results.Add(l);
                   break;
                 case IEnumerable<bool> l:
-                  results.Add( l );
+                  results.Add(l);
                   break;
                 case IEnumerable<string> l:
-                  results.Add( l );
+                  results.Add(l);
                   break;
               }
               isNestedList = true;
               continue;
             }
-            else if ( x is IEnumerable<object> && !( x is IEnumerable<SpeckleObject> ) )
+            else if (x is IEnumerable<object> && !(x is IEnumerable<SpeckleObject>))
             {
-              results.Add( ( ( IEnumerable<object> ) x ).Select( xx => { var res =  Converter.Deserialise( xx as SpeckleObject ); return res == null ? xx : res ; } ).ToList() );
+              results.Add(((IEnumerable<object>)x).Select(xx => { var res = Converter.Deserialise(xx as SpeckleObject); return res == null ? xx : res; }).ToList());
               isNestedList = true;
               continue;
             }
-            else if ( x is IDictionary )
+            else if (x is IDictionary)
             {
-              results.Add( new GH_ObjectWrapper( x ) );
+              results.Add(new GH_ObjectWrapper(x));
               continue;
             }
             else
             {
-              if ( x is bool || x is string || x is double || x is int )
-                results.Add( x );
+              if (x is bool || x is string || x is double || x is int)
+                results.Add(x);
               else
-                results.Add( new GH_ObjectWrapper( Converter.Deserialise( x as SpeckleObject ) ) );
+                results.Add(new GH_ObjectWrapper(Converter.Deserialise(x as SpeckleObject)));
               continue;
             }
           }
 
-          if ( !isNestedList )
-            DA.SetDataList( k++, results );
+          if (!isNestedList)
+            DA.SetDataList(k++, results);
           else
           {
             var tree = new DataTree<object>();
-            ToDataTree( results, ref tree, new List<int> { 0 } );
-            DA.SetDataTree( k++, tree );
+            ToDataTree(results, ref tree, new List<int> { 0 });
+            DA.SetDataTree(k++, tree);
           }
           //DA.SetDataList( k++, global[ key ].Select( x =>
           //{
@@ -235,61 +252,61 @@ namespace SpeckleGrasshopper
       }
     }
 
-    void ToDataTree( IEnumerable list, ref DataTree<object> Tree, List<int> path )
+    void ToDataTree(IEnumerable list, ref DataTree<object> Tree, List<int> path)
     {
       int k = 0;
       int b = 0;
       bool addedRecurse = false;
-      foreach ( var item in list )
+      foreach (var item in list)
       {
-        if ( ( item is IEnumerable ) && !( item is string ) )
+        if ((item is IEnumerable) && !(item is string))
         {
-          if ( !addedRecurse )
+          if (!addedRecurse)
           {
-            path.Add( b );
+            path.Add(b);
             addedRecurse = true;
           }
           else
-            path[ path.Count - 1 ]++;
+            path[path.Count - 1]++;
 
-          ToDataTree( item as IEnumerable, ref Tree, path );
+          ToDataTree(item as IEnumerable, ref Tree, path);
         }
         else
         {
-          GH_Path Path = new GH_Path( path.ToArray() );
-          Tree.Insert( item, Path, k++ );
+          GH_Path Path = new GH_Path(path.ToArray());
+          Tree.Insert(item, Path, k++);
         }
       }
     }
 
-    private Param_GenericObject getGhParameter( string key )
+    private Param_GenericObject getGhParameter(string key)
     {
       Param_GenericObject newParam = new Param_GenericObject();
-      newParam.Name = ( string ) key;
-      newParam.NickName = ( string ) key;
+      newParam.Name = (string)key;
+      newParam.NickName = (string)key;
       newParam.MutableNickName = false;
       newParam.Access = GH_ParamAccess.list;
       return newParam;
     }
 
-    bool IGH_VariableParameterComponent.CanInsertParameter( GH_ParameterSide side, Int32 index )
+    bool IGH_VariableParameterComponent.CanInsertParameter(GH_ParameterSide side, Int32 index)
     {
       return false;
     }
-    bool IGH_VariableParameterComponent.CanRemoveParameter( GH_ParameterSide side, Int32 index )
+    bool IGH_VariableParameterComponent.CanRemoveParameter(GH_ParameterSide side, Int32 index)
     {
       return false;
     }
-    bool IGH_VariableParameterComponent.DestroyParameter( GH_ParameterSide side, Int32 index )
+    bool IGH_VariableParameterComponent.DestroyParameter(GH_ParameterSide side, Int32 index)
     {
       return false;
     }
-    IGH_Param IGH_VariableParameterComponent.CreateParameter( GH_ParameterSide side, Int32 index )
+    IGH_Param IGH_VariableParameterComponent.CreateParameter(GH_ParameterSide side, Int32 index)
     {
       return null;
     }
 
-    public void VariableParameterMaintenance( )
+    public void VariableParameterMaintenance()
     {
     }
 
@@ -309,7 +326,7 @@ namespace SpeckleGrasshopper
     /// </summary>
     public override Guid ComponentGuid
     {
-      get { return new Guid( "{D69F00DD-8F8C-4CE2-8B51-DAE8362844F7}" ); }
+      get { return new Guid("{D69F00DD-8F8C-4CE2-8B51-DAE8362844F7}"); }
     }
   }
 }

--- a/SpeckleGrasshopper/ObjectCreation/ExpandSpeckleObject.cs
+++ b/SpeckleGrasshopper/ObjectCreation/ExpandSpeckleObject.cs
@@ -102,11 +102,19 @@ namespace SpeckleGrasshopper
 
       foreach (var obj in objs)
       {
-        var goo = obj as GH_ObjectWrapper;
-        if (goo == null)
+        GH_ObjectWrapper goo;
+        // FML Code moment: why are objects in gh sometimes NOT wrapped in GH goos? 
+        if ( !( obj is SpeckleObject ) )
         {
-          this.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "We don't like nulls.");
-          return;
+          goo = obj as GH_ObjectWrapper;
+          if ( goo == null )
+          {
+            this.AddRuntimeMessage( GH_RuntimeMessageLevel.Warning, "We don't like nulls." );
+            return;
+          }
+        } else
+        {
+          goo = new GH_ObjectWrapper( obj );
         }
 
         Dictionary<string, object> dict = null;

--- a/SpeckleGrasshopper/Parameters/Param_GenericAccess.cs
+++ b/SpeckleGrasshopper/Parameters/Param_GenericAccess.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Windows.Forms;
+using GH_IO.Serialization;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+
+public class Param_GenericAccess : Param_GenericObject, IDisposable
+{
+  private const string ParamAccessKey = "ParamAccess";
+  public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+  public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
+  {
+    base.AppendAdditionalMenuItems(menu);
+    if (Kind != GH_ParamKind.output)
+    {
+      var item0 = Menu_AppendItem(menu, "Item", Menu_Clicked, true, Access == GH_ParamAccess.item);
+      item0.ToolTipText = "Make this parameter an Item";
+      var item1 = Menu_AppendItem(menu, "Array", Menu_Clicked, true, Access == GH_ParamAccess.list);
+      item1.ToolTipText = "Make this parameters an Array";
+      var item2 = Menu_AppendItem(menu, "Tree", Menu_Clicked, true, Access == GH_ParamAccess.tree);
+      item2.ToolTipText = "Make this parameter a Tree";
+    }
+  }
+
+  public void Dispose()
+  {
+    ClearData();
+  }
+
+  private void Menu_Clicked(object sender, EventArgs e)
+  {
+    var menu = sender as ToolStripMenuItem;
+    var name = menu.AccessibilityObject.Name;
+    RecordUndoEvent("Changing State");
+
+    if (name.Equals("Tree"))
+    {
+      //RecordUndoEvent("tree");
+      Access = GH_ParamAccess.tree;
+    }
+    else if (name.Equals("Array"))
+    {
+      //RecordUndoEvent("array");
+      Access = GH_ParamAccess.list;
+    }
+    else if (name.Equals("Item"))
+    {
+      //RecordUndoEvent("item");
+      Access = GH_ParamAccess.item;
+    }
+
+    OnObjectChanged(GH_ObjectEventType.DataMapping);
+    ExpireSolution(true);
+
+  }
+
+  public override bool Read(GH_IReader reader)
+  {
+    var result = base.Read(reader);
+    if (reader.ItemExists(ParamAccessKey))
+    {
+      try
+      {
+        //In case casting produces invalid Access enum
+        Access = (GH_ParamAccess)reader.GetInt32(ParamAccessKey);
+      }
+      catch (Exception)
+      {
+
+      }
+    }
+    return result;
+  }
+
+  public override Guid ComponentGuid => new Guid("{2E711E3A-573E-42AD-86FF-0B6BA23E9990}");
+
+
+  public override bool Write(GH_IWriter writer)
+  {
+    var result = base.Write(writer);
+    writer.SetInt32(ParamAccessKey, (int)Access);
+    return result;
+  }
+
+}
+
+

--- a/SpeckleGrasshopper/SpeckleGrasshopper.csproj
+++ b/SpeckleGrasshopper/SpeckleGrasshopper.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Management\ListMyStreams.cs" />
     <Compile Include="ObjectCreation\ExpandSpeckleObject.cs" />
     <Compile Include="ObjectCreation\SchemaBuilderComponent.cs" />
+    <Compile Include="Parameters\Param_GenericAccess.cs" />
     <Compile Include="TestComponents\SpeckleConverterDebug.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/SpeckleGrasshopper/SpeckleGrasshopper.csproj
+++ b/SpeckleGrasshopper/SpeckleGrasshopper.csproj
@@ -100,6 +100,7 @@
     <Compile Include="UserDataUtils\GetUserDataComponent.cs" />
     <Compile Include="UserDataUtils\GetValueAtKey.cs" />
     <Compile Include="UserDataUtils\SetUserDataComponent.cs" />
+    <Compile Include="UserDataUtils\SetUserDataSpeckleObjectComponent.cs" />
     <Compile Include="UserDataUtils\UserDataUtilsInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
@@ -58,12 +58,12 @@ namespace SpeckleGrasshopper.UserDataUtils
       
       try
       {
-        var dict = ((GH_ObjectWrapper)dictObject).Value as ArchivableDictionary;
-        speckleObject.Properties.Add(Params.Input[1].NickName, dict);
+        var dict = ((GH_ObjectWrapper)dictObject).Value as Dictionary<string,object>;
+        speckleObject.Properties = dict;
       }
       catch
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Not an Archivable Dictionary, please provide a dictionary");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Cannot set non-dictionary type on speckle object.");
       }
 
       DA.SetData(0, speckleObject);

--- a/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Rhino.Collections;
+using Rhino.Geometry;
+using SpeckleCore;
+using System.Linq;
+
+namespace SpeckleGrasshopper.UserDataUtils
+{
+  public class SetUserDataSpeckleObjectComponent : GH_Component
+  {
+    /// <summary>
+    /// Initializes a new instance of the SetUserDataSpeckleObjectComponent class.
+    /// </summary>
+    public SetUserDataSpeckleObjectComponent()
+      : base("Set User Data Speckle Object", "SUDSO",
+          "Sets user data to a Speckle Object.",
+          "Speckle", "User Data Utils")
+    {
+    }
+
+    /// <summary>
+    /// Registers all the input parameters for this component.
+    /// </summary>
+    protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
+    {
+      pManager.AddParameter(new SpeckleObjectParameter(), "Speckle Object", "SO", "Speckle object to add data to", GH_ParamAccess.item);
+      pManager.AddGenericParameter("User Data", "D", "Data to attach.", GH_ParamAccess.item);
+      pManager[1].Optional = true;
+    }
+
+    /// <summary>
+    /// Registers all the output parameters for this component.
+    /// </summary>
+    protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
+    {
+      pManager.AddParameter(new SpeckleObjectParameter(), "Speckle Object", "SO", "Speckle object to add data to", GH_ParamAccess.item);
+    }
+
+    /// <summary>
+    /// This is the method that actually does the work.
+    /// </summary>
+    /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
+    protected override void SolveInstance(IGH_DataAccess DA)
+    {
+      GH_SpeckleObject GHSpeckleObject = null;
+      if (!DA.GetData(0, ref GHSpeckleObject))
+        return;
+
+      dynamic dictObject = null;
+      DA.GetData(1, ref dictObject);
+
+      var copy = GHSpeckleObject.Duplicate() as GH_SpeckleObject;
+      var speckleObject = copy.Value;
+      
+      try
+      {
+        var dict = ((GH_ObjectWrapper)dictObject).Value as ArchivableDictionary;
+        speckleObject.Properties.Add(Params.Input[1].NickName, dict);
+      }
+      catch
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Not an Archivable Dictionary, please provide a dictionary");
+      }
+
+      DA.SetData(0, speckleObject);
+    }
+
+    /// <summary>
+    /// Provides an Icon for the component.
+    /// </summary>
+    protected override System.Drawing.Bitmap Icon
+    {
+      get
+      {
+        //You can add image files to your project resources and access them like this:
+        // return Resources.IconForThisComponent;
+        return null;
+      }
+    }
+
+    /// <summary>
+    /// Gets the unique ID for this component. Do not change this ID after release.
+    /// </summary>
+    public override Guid ComponentGuid
+    {
+      get { return new Guid("dfb65375-5423-4688-845b-0fd8efe7c6af"); }
+    }
+  }
+}

--- a/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
@@ -59,6 +59,10 @@ namespace SpeckleGrasshopper.UserDataUtils
       try
       {
         var dict = ((GH_ObjectWrapper)dictObject).Value as Dictionary<string,object>;
+        if(dict ==null)
+        {
+          throw new Exception( "Cannot set non-dictionary type on speckle object." );
+        }
         speckleObject.Properties = dict;
       }
       catch
@@ -76,9 +80,8 @@ namespace SpeckleGrasshopper.UserDataUtils
     {
       get
       {
-        //You can add image files to your project resources and access them like this:
-        // return Resources.IconForThisComponent;
-        return null;
+        // TODO: new icon.
+        return Properties.Resources.SetUserData;
       }
     }
 


### PR DESCRIPTION
Removed the necessity of encapsulate list and hid the component. This involved adding 

- a new parameter type that has a context menu for item/list/tree access.
- Create Speckle object now adds that new parameter and handles the case of trees
- Deconstruct Speckle object handles trees
- Optional component that Adds data to a speckle Object, similar to the one that ads on Rhino objects. Note in this case you are not replacing the data just appending.