### PR TITLE
Make "Add User Data Speckle Object" accept all kinds of dictionary

### DIFF
--- a/SpeckleGrasshopper/Loader.cs
+++ b/SpeckleGrasshopper/Loader.cs
@@ -21,6 +21,7 @@ namespace SpeckleGrasshopper
     public override GH_LoadingInstruction PriorityLoad( )
     {
       loadTimer = new System.Timers.Timer( 500 );
+      loadTimer.AutoReset = false;
       loadTimer.Start();
       loadTimer.Elapsed += AddSpeckleMenu;
       return GH_LoadingInstruction.Proceed;

--- a/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
@@ -58,7 +58,7 @@ namespace SpeckleGrasshopper.UserDataUtils
       
       try
       {
-        var dict = ((GH_ObjectWrapper)dictObject).Value as Dictionary<string,object>;
+        var dict = ((GH_ObjectWrapper)dictObject).Value as IDictionary<string,object>;
         if(dict ==null)
         {
           throw new Exception( "Cannot set non-dictionary type on speckle object." );


### PR DESCRIPTION
This is a very minor change to treat incoming user data in the `Set User Data Speckle Object` component as a `IDictionary`, which will allow it to accept any class that matches the interface.